### PR TITLE
Add simulation notebook and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ The simulation works as follows:
     ```
 4.  The script will output the simulation results, showing the number of times each candidate won out of the total simulations performed.
 
+## Running the Notebook
+
+An interactive Jupyter notebook is provided at `notebooks/simulation.ipynb`.
+
+1. Install Jupyter if it is not already available:
+    ```bash
+    pip install notebook
+    ```
+2. Launch the notebook from the repository root:
+    ```bash
+    jupyter notebook notebooks/simulation.ipynb
+    ```
+3. Adjust `poll_weight_factor` and `simulations` in the **Parameters** cell to explore different scenarios.
+4. Run all cells to reproduce the election simulation results. You can also execute the notebook non-interactively:
+    ```bash
+    jupyter nbconvert --to notebook --execute notebooks/simulation.ipynb --output simulation_out.ipynb
+    ```
+
 ## Dependencies
 
 The script uses standard Python libraries:

--- a/notebooks/simulation.ipynb
+++ b/notebooks/simulation.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Election Simulation\n",
+    "This notebook demonstrates running the election simulation with adjustable poll weights and number of simulations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, pathlib, random\n",
+    "root_dir = pathlib.Path().resolve().parent\n",
+    "sys.path.append(str(root_dir))\n",
+    "from election_simulation import State, read_states_info, read_state_list, read_polling_data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "poll_weight_factor = 1.0  # Multiplier applied to each poll weight\n",
+    "simulations = 1000\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data\n",
+    "data_dir = root_dir / \"data\"\n",
+    "\n",
+    "states = read_states_info(data_dir / \"states_info.csv\")\n",
+    "safe_harris = read_state_list(data_dir / \"safe_states_harris.txt\")\n",
+    "safe_trump = read_state_list(data_dir / \"safe_states_trump.txt\")\n",
+    "competitive_states = read_state_list(data_dir / \"competitive_states.txt\")\n",
+    "\n",
+    "for state_name in safe_harris:\n",
+    "    if state_name in states:\n",
+    "        state = states[state_name]\n",
+    "        state.harris_support = 60.0\n",
+    "        state.trump_support = 35.0\n",
+    "        state.std_dev = 2.0\n",
+    "for state_name in safe_trump:\n",
+    "    if state_name in states:\n",
+    "        state = states[state_name]\n",
+    "        state.harris_support = 35.0\n",
+    "        state.trump_support = 60.0\n",
+    "        state.std_dev = 2.0\n",
+    "\n",
+    "polls = read_polling_data(data_dir / \"polling_data.csv\")\n",
+    "for poll in polls:\n",
+    "    state_name = poll['state_name']\n",
+    "    if state_name in states:\n",
+    "        state = states[state_name]\n",
+    "        weight = int(poll['weight'] * poll_weight_factor)\n",
+    "        weight = min(max(weight, 1), 10)\n",
+    "        state.add_poll(\n",
+    "            harris_support=poll['harris_support'],\n",
+    "            trump_support=poll['trump_support'],\n",
+    "            weight=weight,\n",
+    "            moe=poll['moe'],\n",
+    "        )\n",
+    "\n",
+    "for state_name in competitive_states:\n",
+    "    if state_name in states:\n",
+    "        states[state_name].calculate_weighted_support()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run simulations\n",
+    "harris_wins = 0\n",
+    "trump_wins = 0\n",
+    "ties = 0\n",
+    "\n",
+    "for _ in range(simulations):\n",
+    "    harris_evs = 0\n",
+    "    trump_evs = 0\n",
+    "    for state in states.values():\n",
+    "        margin = state.harris_support - state.trump_support\n",
+    "        result = random.gauss(margin, state.std_dev)\n",
+    "        if result > 0:\n",
+    "            harris_evs += state.electoral_votes\n",
+    "        else:\n",
+    "            trump_evs += state.electoral_votes\n",
+    "\n",
+    "    if harris_evs >= 270:\n",
+    "        harris_wins += 1\n",
+    "    elif trump_evs >= 270:\n",
+    "        trump_wins += 1\n",
+    "    else:\n",
+    "        ties += 1\n",
+    "\n",
+    "print(f\"Out of {simulations} simulations:\")\n",
+    "print(f\"Kamala Harris wins: {harris_wins} times\")\n",
+    "print(f\"Donald Trump wins: {trump_wins} times\")\n",
+    "print(f\"Ties or no majority: {ties} times\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add interactive notebook showcasing the election simulation workflow with adjustable poll weighting and simulation count
- document how to run the notebook and reproduce results

## Testing
- `python -m py_compile election_simulation.py`
- `python election_simulation.py`
- `jupyter nbconvert --to notebook --execute notebooks/simulation.ipynb --output /tmp/simulation.out.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_68913227dbc8832ebfe7a22a52ef0856